### PR TITLE
[fix/article-3] @GetMapping parentheses exclusion

### DIFF
--- a/src/main/java/br/com/monkey/ecx/person/web/PersonRestServer.java
+++ b/src/main/java/br/com/monkey/ecx/person/web/PersonRestServer.java
@@ -44,7 +44,7 @@ public class PersonRestServer {
 	public Person findById(@PathVariable String cpf) {
 		return query.findById(cpf);
 	}
-	@GetMapping()
+	@GetMapping
 	@ResponseStatus(HttpStatus.OK)
 	public List<Person> findAll(){
 		return query.findAll();


### PR DESCRIPTION
### Descrição:
foi removido um () desnecessário do código na classe PersonRestServer

### Evidências:
![image](https://user-images.githubusercontent.com/82596129/157459885-90f00022-f8b0-49a5-baed-7065fa027fca.png)


